### PR TITLE
Initial implementation of Vault KV layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,62 @@ secure KV store.
 
 # Usage
 
-TBD
+This layer adds a `vault-kv` relation endpoint to your charm.  Once Vault is
+related and ready (see Flags, below), you can start using either of the KV
+classes.
+
+You can also use the flags to watch for changes to the values in the
+application KV data (see Flags, below).
+
+## Example
+
+```python
+from charms.reactive import when
+from charms.layer import vault_kv
+
+
+@when('layer.vault-kv.ready')
+def use_vault_kv():
+    unit_kv = vault_kv.VaultUnitKV()  # scoped to unit
+    app_kv = vault_kv.VaultAppKV()  # shared across app
+
+    unit_kv['foo'] = 'FOO'
+    unit_kv.set('bar', {'foo': 'FOO'})
+    assert unit_kv.keys() == {'foo', 'bar'}
+    assert unit_kv['foo'] == 'FOO'
+    assert unit_kv['bar']['foo'] = 'FOO'
+
+    app_kv['bar'] = {'bar': 'BAR'}
+    assert app_kv['bar'] != unit_kv['bar']
+    assert app_kv['bar']['bar'] == 'BAR'
+
+
+@when('layer.vault-kv.app-kv.changed.bar')
+def notice_change():
+    status.active('
+```
+
+# Flags
+
+This layer will set the following flags:
+
+  * `layer.vault-kv.ready` When Vault is related and ready to use
+
+  * `layer.vault-kv.app-kv.changed` If any value in the application KV data has
+    changed, whether by this or another unit.  (See [`VaultAppKV.is_changed`][].)
+
+  * `layer.vault-kv.app-kv.changed.{key}` If the value for `{key}` in the
+    application KV data has changed.
+
+  * `layer.vault-kv.app-kv.set.{key}` If a value other than `None` is set for
+    `{key}` in the application KV data.
+
+  * `layer.vault-kv.config.changed` If the connection data has changed.
+
+Note: None of the changed flags will be automatically removed, so it is up to
+the charm to clear them, if needed.  However, to play nicely with other layers,
+base layers using this may wish to [register a trigger][trigger] instead of
+using the flags directly.
 
 # Reference
 
@@ -15,3 +70,5 @@ More information can be found in the [documentation](docs/vault-kv.md).
 
 [interface-vault-kv]: https://github.com/openstack-charmers/charm-interface-vault-kv
 [Vault]: https://vaultproject.io/
+[`VaultAppKV.is_changed`]: docs/vault-kv.md#charms.layer.vault_kv.VaultAppKV.is_changed
+[trigger]: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.flags.html#charms.reactive.flags.register_trigger

--- a/docs/vault-kv.md
+++ b/docs/vault-kv.md
@@ -1,0 +1,98 @@
+<h1 id="charms.layer.vault_kv">charms.layer.vault_kv</h1>
+
+
+<h2 id="charms.layer.vault_kv.VaultNotReady">VaultNotReady</h2>
+
+```python
+VaultNotReady(self, /, *args, **kwargs)
+```
+
+Exception indicating that Vault was accessed before it was ready.
+
+<h2 id="charms.layer.vault_kv.VaultUnitKV">VaultUnitKV</h2>
+
+```python
+VaultUnitKV(self)
+```
+
+A simplified interface for storing data in Vault, with the data scoped to
+the current unit.
+
+Keys must be strings, but data can be structured as long as it is
+JSON-serializable.
+
+This class can be used as a dict, or you can use `self.get` and `self.set`
+for a more KV-like interface. When values are set, via either style, they
+are immediately persisted to Vault. Values are also cached in memory.
+
+Note: This class is a singleton.
+
+<h2 id="charms.layer.vault_kv.VaultAppKV">VaultAppKV</h2>
+
+```python
+VaultAppKV(self)
+```
+
+A simplified interface for storing data in Vault, with data shared by every
+unit of the application.
+
+Keys must be strings, but data can be structured as long as it is
+JSON-serializable.
+
+This class can be used as a dict, or you can use `self.get` and `self.set`
+for a more KV-like interface. When values are set, via either style, they
+are immediately persisted to Vault. Values are also cached in memory.
+
+Note: This class is a singleton.
+
+<h3 id="charms.layer.vault_kv.VaultAppKV.is_changed">is_changed</h3>
+
+```python
+VaultAppKV.is_changed(self, key)
+```
+
+Determine if the value for the given key has changed since the last
+time `self.update_hashes()` has been called.
+
+In order to detect changes, hashes of the values are also sotred
+in Vault.
+
+<h3 id="charms.layer.vault_kv.VaultAppKV.update_hashes">update_hashes</h3>
+
+```python
+VaultAppKV.update_hashes(self)
+```
+
+Update the hashes in Vault, thus marking all fields as unchanged.
+
+This is done automatically at exit.
+
+<h2 id="charms.layer.vault_kv.get_vault_config">get_vault_config</h2>
+
+```python
+get_vault_config()
+```
+
+Get the config data needed for this application to access Vault.
+
+This is only needed if you're using another application, such as
+VaultLocker, using the secrets backend provided by this layer.
+
+Returns a dictionary containing the following keys:
+
+  * vault_url
+  * secret_backend
+  * role_id
+  * secret_id
+
+Note: This data is cached in [UnitData][] so anything with access to that
+could access Vault as this application.
+
+If any of this data changes (such as the secret_id being rotated), this
+layer will set the `layer.vault-kv.config.changed` flag.
+
+If this is called before the Vault relation is available, it will raise
+`VaultNotReady`.
+
+[UnitData]: https://charm-helpers.readthedocs.io/en/latest/api/charmhelpers.core.unitdata.html
+

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,0 +1,3 @@
+repo: https://github.com/juju-solutions/layer-vault-kv
+includes:
+  - 'interface:vault-kv'

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -1,0 +1,208 @@
+import json
+from hashlib import md5
+
+from charmhelpers.core import hookenv
+from charmhelpers.core import unitdata
+from charmhelpers.contrib.openstack.vaultlocker import retrieve_secret_id
+from charms.reactive import data_changed
+from charms.reactive import endpoint_from_flag
+from charms.reactive import set_flag, clear_flag
+
+import hvac
+
+
+class VaultNotReady(Exception):
+    """
+    Exception indicating that Vault was accessed before it was ready.
+    """
+    pass
+
+
+class _Singleton(type):
+    # metaclass to make a class a singleton
+    def __call__(cls, *args, **kwargs):
+        if not isinstance(getattr(cls, '_singleton_instance', None), cls):
+            cls._singleton_instance = super().__call__(*args, **kwargs)
+        return cls._singleton_instance
+
+
+class _VaultBaseKV(dict, metaclass=_Singleton):
+    _client = None  # shared client
+    _path = None  # set by subclasses
+
+    def __init__(self):
+        if not self._client:
+            _VaultBaseKV._client = hvac.Client(url=self._config['vault_url'])
+            _VaultBaseKV._client.auth_approle(self._config['role_id'],
+                                              self._config['secret_id'])
+        response = self._client.read(self._path)
+        super().__init__(response['data'] if response else {})
+
+    @property
+    def _config(self):
+        _VaultBaseKV._config = get_vault_config()
+        return _VaultBaseKV._config
+
+    def __setitem__(self, key, value):
+        self._client.write(self._path, **{key: value})
+        super().__setitem__(key, value)
+
+    def set(self, key, value):
+        # alias in case a KV-like interface is preferred
+        self[key] = value
+
+
+class VaultUnitKV(_VaultBaseKV):
+    """
+    A simplified interface for storing data in Vault, with the data scoped to
+    the current unit.
+
+    Keys must be strings, but data can be structured as long as it is
+    JSON-serializable.
+
+    This class can be used as a dict, or you can use `self.get` and `self.set`
+    for a more KV-like interface. When values are set, via either style, they
+    are immediately persisted to Vault. Values are also cached in memory.
+
+    Note: This class is a singleton.
+    """
+    def __init__(self):
+        unit_num = hookenv.local_unit().split('/')[1]
+        self._path = '{}/kv/unit/{}'.format(self._config['secret_backend'],
+                                            unit_num)
+        super().__init__()
+
+
+class VaultAppKV(_VaultBaseKV):
+    """
+    A simplified interface for storing data in Vault, with data shared by every
+    unit of the application.
+
+    Keys must be strings, but data can be structured as long as it is
+    JSON-serializable.
+
+    This class can be used as a dict, or you can use `self.get` and `self.set`
+    for a more KV-like interface. When values are set, via either style, they
+    are immediately persisted to Vault. Values are also cached in memory.
+
+    Note: This class is a singleton.
+    """
+    def __init__(self):
+        self._path = '{}/kv/app'.format(self._config['secret_backend'])
+        self._hash_path = '{}/kv/app-hashes/{}'.format(
+            self._config['secret_backend'],
+            hookenv.local_unit().split('/')[1])
+        super().__init__()
+        self._load_hashes()
+
+    def _load_hashes(self):
+        response = self._client.read(self._hash_path)
+        self._old_hashes = response['data'] if response else {}
+        self._new_hashes = {}
+        for key in self.keys():
+            self._rehash(key)
+
+    def _rehash(self, key):
+        serialized = json.dumps(self[key], sort_keys=True).encode('utf8')
+        self._new_hashes[key] = md5(serialized).hexdigest()
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        self._rehash(key)
+        self._manage_flags(key)
+
+    def _manage_flags(self, key):
+        flag_any_changed = 'layer.vault-kv.app-kv.changed'
+        flag_key_changed = 'layer.vault-kv.app-kv.changed.{}'.format(key)
+        flag_key_set = 'layer.vault-kv.app-kv.set.{}'.format(key)
+        if self.is_changed(key):
+            # clear then set flag to ensure triggers are run even if the main
+            # flag was never cleared
+            clear_flag(flag_any_changed)
+            set_flag(flag_any_changed)
+            clear_flag(flag_key_changed)
+            set_flag(flag_key_changed)
+        if self.get(key) is not None:
+            set_flag(flag_key_set)
+        else:
+            clear_flag(flag_key_set)
+
+    def is_changed(self, key):
+        """
+        Determine if the value for the given key has changed since the last
+        time `self.update_hashes()` has been called.
+
+        In order to detect changes, hashes of the values are also stored
+        in Vault.
+        """
+        return self._new_hashes.get(key) == self._old_hashes.get(key)
+
+    def update_hashes(self):
+        """
+        Update the hashes in Vault, thus marking all fields as unchanged.
+
+        This is done automatically at exit.
+        """
+        self._client.write(self._hash_path, **self._new_hashes)
+        self._old_hashes.clear()
+        self._old_hashes.update(self._new_hashes)
+
+
+def get_vault_config():
+    """
+    Get the config data needed for this application to access Vault.
+
+    This is only needed if you're using another application, such as
+    VaultLocker, using the secrets backend provided by this layer.
+
+    Returns a dictionary containing the following keys:
+
+      * vault_url
+      * secret_backend
+      * role_id
+      * secret_id
+
+    Note: This data is cached in [UnitData][] so anything with access to that
+    could access Vault as this application.
+
+    If any of this data changes (such as the secret_id being rotated), this
+    layer will set the `layer.vault-kv.config.changed` flag.
+
+    If this is called before the Vault relation is available, it will raise
+    `VaultNotReady`.
+
+    [UnitData]: https://charm-helpers.readthedocs.io/en/latest/api/charmhelpers.core.unitdata.html
+    """  # noqa
+    vault = endpoint_from_flag('vault-kv.available')
+    if not vault:
+        raise VaultNotReady()
+    return {
+        'vault_url': vault.vault_url,
+        'secret_backend': _get_secret_backend(),
+        'role_id': vault.unit_role_id,
+        'secret_id': _get_secret_id(vault),
+    }
+
+
+def _get_secret_backend():
+    app_name = hookenv.application_name()
+    return 'charm-{}'.format(app_name)
+
+
+def _get_secret_id(vault):
+    token = vault.unit_token
+    if data_changed('layer.vault-kv.token', token):
+        # token is one-shot, but if it changes it might mean that we're
+        # being told to rotate the secret ID, or we might not have fetched
+        # one yet
+        vault_url = vault.vault_url
+        secret_id = retrieve_secret_id(vault_url, token)
+        unitdata.kv().set('layer.vault-kv.secret_id', secret_id)
+        # have to flush immediately because if we don't and hit some error
+        # elsewhere, it could get us into a state where we have forgotten the
+        # secret ID and can't retrieve it again because we've already used the
+        # token
+        unitdata.kv().flush()
+    else:
+        secret_id = unitdata.kv().get('layer.vault-kv.secret_id')
+    return secret_id

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,3 @@
+requires:
+  vault-kv:
+    interface: vault-kv

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -2,7 +2,7 @@ site_name: 'Vault Secure KV Store Layer'
 
 generate:
   - vault-kv.md:
-    - charms.layer.vault_kv+
+    - charms.layer.vault_kv++
 
 pages:
   - Vault Secure KV Store Layer: vault-kv.md

--- a/reactive/vault_kv.py
+++ b/reactive/vault_kv.py
@@ -1,0 +1,55 @@
+from charmhelpers.core import hookenv
+from charms.reactive import when_all, when_not, set_flag, clear_flag
+from charms.reactive import endpoint_from_flag
+from charms.reactive import data_changed
+
+from charms.layer import vault_kv
+
+
+@when_all('vault-kv.connected')
+@when_not('layer.vault-kv.requested')
+def request_vault_access():
+    vault = endpoint_from_flag('vault-kv.connected')
+    # backend can't be isolated or VaultAppKV won't work; see issue #2
+    vault.request_secret_backend(vault_kv._get_secret_backend(),
+                                 isolated=False)
+    set_flag('layer.vault-kv.requested')
+
+
+@when_all('vault-kv.available')
+def set_ready():
+    set_flag('layer.vault-kv.ready')
+
+
+@when_all('layer.vault-kv.ready')
+def check_config_changed():
+    config = vault_kv.get_vault_config()
+    if data_changed('layer.vault-kv.config', config):
+        set_flag('layer.vault-kv.config.changed')
+
+
+@when_not('vault-kv.connected')
+def clear_ready():
+    clear_flag('layer.vault-kv.ready')
+    clear_flag('layer.vault-kv.requested')
+
+
+def manage_app_kv_flags():
+    try:
+        app_kv = vault_kv.VaultAppKV()
+        for key in app_kv.keys():
+            app_kv._manage_flags(key)
+    except vault_kv.VaultNotReady:
+        return
+
+
+def update_app_kv_hashes():
+    try:
+        app_kv = vault_kv.VaultAppKV()
+        app_kv.update_hashes()
+    except vault_kv.VaultNotReady:
+        return
+
+
+hookenv.atstart(manage_app_kv_flags)
+hookenv.atexit(update_app_kv_hashes)

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps=
   pytest
   charms.reactive
   pydoc-markdown
+  hvac
   # needed to prevent apt installs during import
   netifaces
   psutil

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,4 @@
+hvac
+# needed to prevent apt installs during import
+netifaces
+psutil


### PR DESCRIPTION
Provides a simplified interface for connecting to and storing data in Vault.  A major use-case for this is to act as a near drop-in replacement for leader data for things that need to be secure but also shared across units, such as generated encryption keys.  For example: https://github.com/juju-solutions/kubernetes/commit/01bd548bc650d4966c922026e7ba293688794800