### PR TITLE
Fix Vault client having auth timeout

### DIFF
--- a/reactive/vault_kv.py
+++ b/reactive/vault_kv.py
@@ -10,9 +10,9 @@ from charms.layer import vault_kv
 @when_not('layer.vault-kv.requested')
 def request_vault_access():
     vault = endpoint_from_flag('vault-kv.connected')
+    backend_name = vault_kv._get_secret_backend()
     # backend can't be isolated or VaultAppKV won't work; see issue #2
-    vault.request_secret_backend(vault_kv._get_secret_backend(),
-                                 isolated=False)
+    vault.request_secret_backend(backend_name, isolated=False)
     set_flag('layer.vault-kv.requested')
 
 


### PR DESCRIPTION
The auth token received when doing the `auth_approle()` only lasts for 60s.  When the charm hook takes longer than that to complete, the `atexit` handler for updating the hashes will fail with "permission denied" due to the auth timeout.

Fixes: [lp:1843809](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1843809)