### PR TITLE
Fix hook error during update_app_kv_hashes

### DIFF
--- a/reactive/vault_kv.py
+++ b/reactive/vault_kv.py
@@ -58,7 +58,7 @@ def update_app_kv_hashes():
         if hookenv.is_leader() and app_kv.any_changed():
             # force hooks to run on non-leader units
             hookenv.leader_set({'vault-kv-nonce': host.pwgen(8)})
-        app_kv.update_hashes()
+            app_kv.update_hashes()
     except vault_kv.VaultNotReady:
         return
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1863328

I tested this by running [test_encryption_at_rest](https://github.com/charmed-kubernetes/jenkins/blob/9e03d927ffaee42245fb41fb05a157ad5d047264/jobs/integration/validation.py#L1335). Prior to this fix, the test consistently failed due to hook error. With this fix applied, I was able to run the test 2 times with no failure.