### PR TITLE
Convert clear_ready to use triggers

### DIFF
--- a/reactive/vault_kv.py
+++ b/reactive/vault_kv.py
@@ -1,9 +1,15 @@
 from charmhelpers.core import hookenv, host
 from charms.reactive import when_all, when_not, set_flag, clear_flag
-from charms.reactive import endpoint_from_flag
+from charms.reactive import endpoint_from_flag, register_trigger
 from charms.reactive import data_changed
 
 from charms.layer import vault_kv
+
+
+register_trigger(when_not='vault-kv.connected',
+                 clear_flag='layer.vault-kv.ready')
+register_trigger(when_not='vault-kv.connected',
+                 clear_flag='layer.vault-kv.requested')
 
 
 @when_all('vault-kv.connected')
@@ -35,12 +41,6 @@ def check_config_changed():
     else:
         if data_changed('layer.vault-kv.config', config):
             set_flag('layer.vault-kv.config.changed')
-
-
-@when_not('vault-kv.connected')
-def clear_ready():
-    clear_flag('layer.vault-kv.ready')
-    clear_flag('layer.vault-kv.requested')
 
 
 def manage_app_kv_flags():


### PR DESCRIPTION
This prevents a window where other handlers might run based on the layer flags after the interface is disconnected but before the clear_ready handler has a chance to run.

Part of the fix for [LP: #1844103](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1844103)