### PR TITLE
Catch InternalServerError from Vault

### DIFF
--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -64,6 +64,7 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
             hvac.exceptions.VaultDown,
             hvac.exceptions.VaultNotInitialized,
             hvac.exceptions.BadGateway,
+            hvac.exceptions.InternalServerError,
         ) as e:
             raise VaultNotReady() from e
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1988448

This will wrap the InternalServerError exception in VaultNotReady, which is caught and handled [here](https://github.com/charmed-kubernetes/layer-vault-kv/blob/6aedcd2f267678648d0b905b49c24bdb9fc9e690/reactive/vault_kv.py#L27), [here](https://github.com/charmed-kubernetes/layer-vault-kv/blob/6aedcd2f267678648d0b905b49c24bdb9fc9e690/reactive/vault_kv.py#L37), [here](https://github.com/charmed-kubernetes/layer-vault-kv/blob/6aedcd2f267678648d0b905b49c24bdb9fc9e690/reactive/vault_kv.py#L49) and [here](https://github.com/charmed-kubernetes/layer-vault-kv/blob/main/reactive/vault_kv.py#L62). I think that should cover us here, but I can't say for sure since we don't have a reliable reproducer.