### PR TITLE
update hvac by including poetry-core and pinning zipp

### DIFF
--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -57,7 +57,7 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
                 vault_url=self._config["vault_url"],
             )
             client = hvac.Client(url=self._config["vault_url"])
-            client.auth_approle(self._config["role_id"], self._config["secret_id"])
+            client.auth.approle.login(self._config["role_id"], self._config["secret_id"])
             return client
         except (
             requests.exceptions.ConnectionError,

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -58,7 +58,7 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
             )
             client = hvac.Client(url=self._config["vault_url"])
             client.auth.approle.login(
-                self._config["role_id"], self._config["secret_id"]
+                self._config["role_id"], secret_id=self._config["secret_id"]
             )
             return client
         except (

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -57,7 +57,9 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
                 vault_url=self._config["vault_url"],
             )
             client = hvac.Client(url=self._config["vault_url"])
-            client.auth.approle.login(self._config["role_id"], self._config["secret_id"])
+            client.auth.approle.login(
+                self._config["role_id"], self._config["secret_id"]
+            )
             return client
         except (
             requests.exceptions.ConnectionError,

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,13 @@ commands =
     flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
     black --check {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
 
+[testenv:format]
+deps =
+    black
+commands =
+    black {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
+
+
 [testenv:docs]
 deps=
   ipdb

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,5 +1,15 @@
-hvac < 1.0.0
+hvac
 # needed to prevent apt installs during import
 netifaces
 psutil
 
+# needed to build hvac wheel
+poetry-core>=1.0.0
+
+# needed as a dep of hvac
+# it comes with a useful compatibility listing
+# Lifted from https://github.com/jaraco/zipp#compatibility
+zipp<1.0;python_version < '3.8'
+zipp<3.3;python_version < '3.9'
+zipp<3.5;python_version < '3.11'
+zipp<3.9;python_version < '3.12'


### PR DESCRIPTION
Requires https://github.com/juju/charm-helpers/pull/745 first be merged and published to pypi before merging
* https://github.com/juju/charm-helpers/pull/745

The above is merged, but a new charmhelpers must be published to pypi