### PR TITLE
Catch vault InternalServerError in _get_secret_id

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.10]
+        python: ["3.8", "3.9", "3.10"]
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.8, 3.9, 3.10]
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
         python: [3.6, 3.7, 3.8, 3.9]
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install Dependencies

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -261,6 +261,7 @@ def _get_secret_id(vault):
             hvac.exceptions.VaultDown,
             hvac.exceptions.VaultNotInitialized,
             hvac.exceptions.BadGateway,
+            hvac.exceptions.InternalServerError,
         ) as e:
             raise VaultNotReady() from e
         unitdata.kv().set("layer.vault-kv.secret_id", secret_id)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [flake8]
 max-line-length = 88
 ignore =
-    W503 # line break before binary operator
+    # line break before binary operator
+    W503
 
 [pytest]
 addopts = --cov-report=term-missing --cov=reactive --cov=lib --cov-report=html


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1989362

Similar to https://github.com/juju-solutions/layer-vault-kv/pull/15, which applied this fix to the `_client` function. I missed that vault exceptions can be raised in the `_get_secret_id` function too.