### PR TITLE
[LP#1949913] Support a layer configurable option to change the secrets backend index

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -12,5 +12,5 @@ defines:
          that secrets name can be formatted using the following substitutions
       
       variables
-      * model-uuid - juju model-uuid
-      * app        - juju application name
+      * model-uuid - juju model-uuid loaded from hookenv.model_uuid()
+      * app        - juju application-name loaded from hookenv.application_name()

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,16 @@
 repo: https://github.com/juju-solutions/layer-vault-kv
 includes:
+  - 'layer:options'
   - 'interface:vault-kv'
+defines:
+  secrets-backend-format:
+    type: string
+    default: "charm-{app}"
+    description: |-
+      VaultAppKV requests a secrets backend secret storage
+         from vault over the vault-kv interface
+         that secrets name can be formatted using the following substitutions
+      
+      variables
+      * model-uuid - juju model-uuid
+      * app        - juju application name

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -1,7 +1,5 @@
 import json
-import yaml
 from functools import cached_property
-from pathlib import Path
 from hashlib import md5
 
 from charmhelpers.core import hookenv

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -1,9 +1,13 @@
 import json
+import yaml
+from functools import cached_property
+from pathlib import Path
 from hashlib import md5
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
 from charmhelpers.contrib.openstack.vaultlocker import retrieve_secret_id
+from charms.layer import options
 from charms.reactive import data_changed, is_data_changed
 from charms.reactive import endpoint_from_flag
 from charms.reactive import set_flag, clear_flag, get_flags
@@ -35,6 +39,7 @@ class _Singleton(type):
 
 
 class _VaultBaseKV(dict, metaclass=_Singleton):
+    _kwds = {}  # set by subclasses
     _path = None  # set by subclasses
 
     def __init__(self):
@@ -70,10 +75,9 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
         ) as e:
             raise VaultNotReady() from e
 
-    @property
+    @cached_property
     def _config(self):
-        _VaultBaseKV._config = get_vault_config()
-        return _VaultBaseKV._config
+        return get_vault_config(**self._kwds)
 
     def __setitem__(self, key, value):
         log("Writing data to vault")
@@ -100,7 +104,8 @@ class VaultUnitKV(_VaultBaseKV):
     Note: This class is a singleton.
     """
 
-    def __init__(self):
+    def __init__(self, *_, **kwds):
+        self._kwds = kwds
         unit_num = hookenv.local_unit().split("/")[1]
         self._path = "{}/kv/unit/{}".format(self._config["secret_backend"], unit_num)
         super().__init__()
@@ -126,7 +131,8 @@ class VaultAppKV(_VaultBaseKV):
     Note: This class is a singleton.
     """
 
-    def __init__(self):
+    def __init__(self, *_, **kwds):
+        self._kwds = kwds
         self._path = "{}/kv/app".format(self._config["secret_backend"])
         self._hash_path = "{}/kv/app-hashes/{}".format(
             self._config["secret_backend"], hookenv.local_unit().split("/")[1]
@@ -206,7 +212,7 @@ class VaultAppKV(_VaultBaseKV):
         self._old_hashes.update(self._new_hashes)
 
 
-def get_vault_config():
+def get_vault_config(**kwds):
     """
     Get the config data needed for this application to access Vault.
 
@@ -236,16 +242,24 @@ def get_vault_config():
         raise VaultNotReady()
     vault_config = {
         "vault_url": vault.vault_url,
-        "secret_backend": _get_secret_backend(),
+        "secret_backend": _get_secret_backend(**kwds),
         "role_id": vault.unit_role_id,
         "secret_id": _get_secret_id(vault),
     }
     return vault_config
 
 
-def _get_secret_backend():
-    app_name = hookenv.application_name()
-    return "charm-{}".format(app_name)
+def _get_secret_backend_format():
+    return options.get("vault-kv", "secrets-backend-format")
+
+
+def _get_secret_backend(backend_format: str = None, **_):
+    variables = {
+        "model-uuid": hookenv.model_uuid(),
+        "app": hookenv.application_name(),
+    }
+    fmt = backend_format if backend_format else _get_secret_backend_format()
+    return fmt.format(**variables)
 
 
 def _get_secret_id(vault):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,7 +40,7 @@ os.environ["JUJU_AVAILABILITY_ZONE"] = ""
 options = patch_module("charms.layer.options")
 options.get.return_value = "charm-{app}"
 
-from charms.layer.vault_kv import VaultAppKV, VaultUnitKV
+from charms.layer.vault_kv import VaultAppKV, VaultUnitKV  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from charms.unit_test import patch_module, identity, MockKV, flags, MockEndpoint
 
@@ -34,3 +35,18 @@ os.environ["JUJU_MODEL_UUID"] = "test-1234"
 os.environ["JUJU_UNIT_NAME"] = "test/0"
 os.environ["JUJU_MACHINE_ID"] = "0"
 os.environ["JUJU_AVAILABILITY_ZONE"] = ""
+
+
+options = patch_module("charms.layer.options")
+options.get.return_value = "charm-{app}"
+
+from charms.layer.vault_kv import VaultAppKV, VaultUnitKV
+
+
+@pytest.fixture(autouse=True)
+def destroy_vault_kv():
+    """Teardown singleton instance created in each unit test."""
+    yield
+    for cls in (VaultAppKV, VaultUnitKV):
+        if hasattr(cls, "_singleton_instance"):
+            del cls._singleton_instance

--- a/tests/unit/test_reactive.py
+++ b/tests/unit/test_reactive.py
@@ -20,19 +20,12 @@ def mock_vault_config():
         yield vc
 
 
-@pytest.fixture()
-def destroy_vault_kv():
-    """Teardown singleton instance created in each unit test."""
-    yield
-    del VaultAppKV._singleton_instance
-
-
 @patch("hvac.Client", autospec=True)
 @patch("charmhelpers.core.hookenv.local_unit", Mock(return_value="unit-test/0"))
 @patch("charmhelpers.core.hookenv.is_leader", Mock(return_value=True))
 @patch("charmhelpers.core.hookenv.leader_set")
 def test_update_app_kv_hashes_leader(
-    mock_leader_set, mock_hvac_client, mock_vault_config, destroy_vault_kv
+    mock_leader_set, mock_hvac_client, mock_vault_config
 ):
     def mock_read(path):
         if path == "charm-unit-test/kv/app":
@@ -68,7 +61,7 @@ def test_update_app_kv_hashes_leader(
 @patch("charmhelpers.core.hookenv.is_leader", Mock(return_value=False))
 @patch("charmhelpers.core.hookenv.leader_set")
 def test_update_app_kv_hashes_follower(
-    mock_leader_set, mock_hvac_client, mock_vault_config, destroy_vault_kv
+    mock_leader_set, mock_hvac_client, mock_vault_config
 ):
     def mock_read(path):
         if path == "charm-unit-test/kv/app":

--- a/tests/unit/test_reactive.py
+++ b/tests/unit/test_reactive.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, Mock
 import pytest
 
 from reactive.vault_kv import update_app_kv_hashes
-from charms.layer.vault_kv import VaultAppKV
 
 
 @pytest.fixture()

--- a/tests/unit/test_vault_kv.py
+++ b/tests/unit/test_vault_kv.py
@@ -7,7 +7,6 @@ from charms.layer.vault_kv import (
     get_vault_config,
     VaultAppKV,
     VaultNotReady,
-    VaultUnitKV,
 )
 from charms.reactive import endpoint_from_flag, is_data_changed, data_changed
 from charmhelpers.core import unitdata, hookenv
@@ -93,11 +92,8 @@ def test_get_vault_config_fails_get_secret_id(mock_rtv_secret_id, vault):
 @mock.patch("charms.layer.vault_kv.retrieve_secret_id")
 def test_vault_app_kv_singleton(mock_rtv_secret_id, mock_client, backend_format):
     mock_client().read.return_value = dict(data={})
-    with mock.patch.object(
-        unitdata.kv.return_value, "flush", create=True
-    ) as mock_flush:
+    with mock.patch.object(unitdata.kv.return_value, "flush", create=True):
         mock_rtv_secret_id.return_value = "secret-from-token-value"
-
         kv = VaultAppKV(backend_format=backend_format)
         kv2 = VaultAppKV()
 

--- a/tests/unit/test_vault_kv.py
+++ b/tests/unit/test_vault_kv.py
@@ -3,44 +3,70 @@ from unittest import mock
 import pytest
 import hvac.exceptions
 
-from charms.layer.vault_kv import get_vault_config, VaultNotReady
+from charms.layer.vault_kv import (
+    get_vault_config,
+    VaultAppKV,
+    VaultNotReady,
+    VaultUnitKV,
+)
 from charms.reactive import endpoint_from_flag, is_data_changed, data_changed
 from charmhelpers.core import unitdata, hookenv
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def vault():
     """Mock vault kv endpoint"""
-    vault = endpoint_from_flag("vault-kv.available")
-    vault.vault_url = "https://test.me:4040"
-    vault.unit_role_id = "test-role-id"
-    vault.unit_token = "some-secret-token-value"
+    endpoint = endpoint_from_flag("vault-kv.available")
+    endpoint.vault_url = "https://test.me:4040"
+    endpoint.unit_role_id = "test-role-id"
+    endpoint.unit_token = "some-secret-token-value"
     hookenv.application_name.return_value = "my-juju-app"
+    hookenv.model_uuid.return_value = "11111111-2222-3333-4444-555555555555"
     is_data_changed.return_value = True
 
-    yield vault
+    yield endpoint
 
     hookenv.application_name.reset_mock()
+    hookenv.model_uuid.reset_mock()
     data_changed.reset_mock()
     is_data_changed.reset_mock()
 
 
+@pytest.fixture(params=["", "charm-{app}", "charm-{model-uuid}-{app}"])
+def backend_format(request):
+    class Formatter(str):
+        @property
+        def expected(self):
+            fmt = self
+            if fmt == "":
+                fmt = "charm-{app}"
+            context = {
+                "model-uuid": hookenv.model_uuid.return_value,
+                "app": hookenv.application_name.return_value,
+            }
+            return fmt.format(**context)
+
+    yield Formatter(request.param)
+    hookenv.application_name.assert_called_once_with()
+    hookenv.model_uuid.assert_called_once_with()
+
+
 @mock.patch("charms.layer.vault_kv.retrieve_secret_id")
-def test_get_vault_config_success(mock_rtv_secret_id, vault):
+def test_get_vault_config_success(mock_rtv_secret_id, vault, backend_format):
     """Confirm vault config can be retrieved with valid relation data."""
 
     with mock.patch.object(
         unitdata.kv.return_value, "flush", create=True
     ) as mock_flush:
         mock_rtv_secret_id.return_value = "secret-from-token-value"
-        vault_config = get_vault_config()
+        vault_config = get_vault_config(backend_format=backend_format)
 
     mock_rtv_secret_id.assert_called_once_with(vault.vault_url, vault.unit_token)
     data_changed.assert_called_once_with("layer.vault-kv.token", vault.unit_token)
     mock_flush.assert_called_once_with()
     assert vault_config == {
         "vault_url": vault.vault_url,
-        "secret_backend": f"charm-{hookenv.application_name.return_value}",
+        "secret_backend": backend_format.expected,
         "role_id": vault.unit_role_id,
         "secret_id": "secret-from-token-value",
     }
@@ -61,3 +87,36 @@ def test_get_vault_config_fails_get_secret_id(mock_rtv_secret_id, vault):
     is_data_changed.assert_called_once_with("layer.vault-kv.token", vault.unit_token)
     mock_rtv_secret_id.assert_called_once_with(vault.vault_url, vault.unit_token)
     data_changed.assert_not_called()
+
+
+@mock.patch("hvac.Client", autospec=True)
+@mock.patch("charms.layer.vault_kv.retrieve_secret_id")
+def test_vault_app_kv_singleton(mock_rtv_secret_id, mock_client, backend_format):
+    mock_client().read.return_value = dict(data={})
+    with mock.patch.object(
+        unitdata.kv.return_value, "flush", create=True
+    ) as mock_flush:
+        mock_rtv_secret_id.return_value = "secret-from-token-value"
+
+        kv = VaultAppKV(backend_format=backend_format)
+        kv2 = VaultAppKV()
+
+    assert kv is kv2, "Should be singleton instances"
+    assert kv._config["secret_backend"] == backend_format.expected
+
+    # Nothing yet set
+    assert kv.keys() == set()
+    mock_client().write.assert_not_called()
+
+    kv["settable"] = "value"
+    mock_client().write.assert_called_once_with(
+        f"{backend_format.expected}/kv/app", settable="value"
+    )
+    mock_client().write.reset_mock()
+
+    kv.set("settable", "new-value")
+    mock_client().write.assert_called_once_with(
+        f"{backend_format.expected}/kv/app", settable="new-value"
+    )
+
+    assert dict(kv.items()) == {"settable": "new-value"}


### PR DESCRIPTION
In order to support a charm's ability to compile time switch to a different secrets-backend storage name, this layer needs to support an option to provide the charm the ability to format the storage name. 


* adds `secrets-backend-format` option which allows for a configurable format string to define the secrets store in vault
* Allows for both `VaultAppKV` and `VaultUnitKV` to be created with a `backend_format` argument which can override the layer option.  Keep in mind these classes are singletons, and can only reference a single backend per hook invocation
* testing upgrades

Associated with 
* https://github.com/openstack-charmers/charm-interface-vault-kv/pull/14