### PR TITLE
the `_VaultBaseKV._read_path(...)` method ignored the argument `path`

### DIFF
--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -54,7 +54,7 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
         that path. Whatever the case, raise VaultNotReady()
         """
         try:
-            return self._client.read(self._path)
+            return self._client.read(path)
         except hvac.exceptions.Forbidden as e:
             raise VaultNotReady() from e
 


### PR DESCRIPTION
The base class method for reading from vault has a method called `_read_path(...) ` introduced in https://github.com/juju-solutions/layer-vault-kv/pull/20

This should execute an http request on a specified `path` but wasn't using that argument.  This caused the app_hash cache in vault to always be incorrect and look like a new encryption key was needing to be written. 