### PR TITLE
Add pylinting to catch future unused-arguments

### DIFF
--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -1,3 +1,5 @@
+"""Library for vault_kv layer and available to the charm layer."""
+
 import json
 from functools import cached_property
 from hashlib import md5
@@ -5,6 +7,8 @@ from hashlib import md5
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
 from charmhelpers.contrib.openstack.vaultlocker import retrieve_secret_id
+
+# pylint: disable-next=no-name-in-module; this is imported via layer-options
 from charms.layer import options
 from charms.reactive import data_changed, is_data_changed
 from charms.reactive import endpoint_from_flag
@@ -15,17 +19,14 @@ import hvac
 
 
 def log(msg, *args, **kwargs):
-    hookenv.log(
-        "vault-kv.log: {}".format(msg.format(*args, **kwargs)), level=hookenv.DEBUG
-    )
+    """Simplified logger for this lib."""
+    hookenv.log(f"vault-kv.log: {msg.format(*args, **kwargs)}", level=hookenv.DEBUG)
 
 
 class VaultNotReady(Exception):
     """
     Exception indicating that Vault was accessed before it was ready.
     """
-
-    pass
 
 
 class _Singleton(type):
@@ -55,8 +56,8 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
         """
         try:
             return self._client.read(path)
-        except hvac.exceptions.Forbidden as e:
-            raise VaultNotReady() from e
+        except hvac.exceptions.Forbidden as ex:
+            raise VaultNotReady() from ex
 
     @property
     def _client(self):
@@ -83,8 +84,8 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
             hvac.exceptions.VaultNotInitialized,
             hvac.exceptions.BadGateway,
             hvac.exceptions.InternalServerError,
-        ) as e:
-            raise VaultNotReady() from e
+        ) as ex:
+            raise VaultNotReady() from ex
 
     @cached_property
     def _config(self):
@@ -96,7 +97,7 @@ class _VaultBaseKV(dict, metaclass=_Singleton):
         super().__setitem__(key, value)
 
     def set(self, key, value):
-        # alias in case a KV-like interface is preferred
+        """alias in case a KV-like interface is preferred."""
         self[key] = value
 
 
@@ -118,7 +119,7 @@ class VaultUnitKV(_VaultBaseKV):
     def __init__(self, *_, **kwds):
         self._kwds = kwds
         unit_num = hookenv.local_unit().split("/")[1]
-        self._path = "{}/kv/unit/{}".format(self._config["secret_backend"], unit_num)
+        self._path = f"{self._config['secret_backend']}/kv/unit/{unit_num}"
         super().__init__()
 
 
@@ -144,10 +145,12 @@ class VaultAppKV(_VaultBaseKV):
 
     def __init__(self, *_, **kwds):
         self._kwds = kwds
-        self._path = "{}/kv/app".format(self._config["secret_backend"])
-        self._hash_path = "{}/kv/app-hashes/{}".format(
-            self._config["secret_backend"], hookenv.local_unit().split("/")[1]
-        )
+        # self._kwds attrribute must be set first
+        # as _config attribute is based off its values
+        backend = self._config["secret_backend"]
+        app = hookenv.local_unit().split("/")[1]
+        self._path = f"{backend}/kv/app"
+        self._hash_path = f"{backend}/kv/app-hashes/{app}"
         super().__init__()
         self._load_hashes()
 
@@ -170,8 +173,8 @@ class VaultAppKV(_VaultBaseKV):
 
     def _manage_flags(self, key):
         flag_any_changed = "layer.vault-kv.app-kv.changed"
-        flag_key_changed = "layer.vault-kv.app-kv.changed.{}".format(key)
-        flag_key_set = "layer.vault-kv.app-kv.set.{}".format(key)
+        flag_key_changed = f"layer.vault-kv.app-kv.changed.{key}"
+        flag_key_set = f"layer.vault-kv.app-kv.set.{key}"
         if self.is_changed(key):
             # clear then set flag to ensure triggers are run even if the main
             # flag was never cleared
@@ -289,8 +292,8 @@ def _get_secret_id(vault):
             hvac.exceptions.VaultNotInitialized,
             hvac.exceptions.BadGateway,
             hvac.exceptions.InternalServerError,
-        ) as e:
-            raise VaultNotReady() from e
+        ) as ex:
+            raise VaultNotReady() from ex
 
         # update the token in the unitdata.kv now that its been
         # successfully used to retrieve the secret_id

--- a/lib/charms/layer/vault_kv.py
+++ b/lib/charms/layer/vault_kv.py
@@ -148,9 +148,9 @@ class VaultAppKV(_VaultBaseKV):
         # self._kwds attrribute must be set first
         # as _config attribute is based off its values
         backend = self._config["secret_backend"]
-        app = hookenv.local_unit().split("/")[1]
+        unit_num = hookenv.local_unit().split("/")[1]
         self._path = f"{backend}/kv/app"
-        self._hash_path = f"{backend}/kv/app-hashes/{app}"
+        self._hash_path = f"{backend}/kv/app-hashes/{unit_num}"
         super().__init__()
         self._load_hashes()
 

--- a/reactive/vault_kv.py
+++ b/reactive/vault_kv.py
@@ -1,3 +1,5 @@
+"""Reactive module for vault-kv, complete with all reactive hooks."""
+
 from charmhelpers.core import hookenv, host
 from charms.reactive import when_all, when_not, set_flag, clear_flag
 from charms.reactive import endpoint_from_flag, register_trigger
@@ -13,7 +15,9 @@ register_trigger(when_not="vault-kv.connected", clear_flag="layer.vault-kv.reque
 @when_all("vault-kv.connected")
 @when_not("layer.vault-kv.requested")
 def request_vault_access():
+    """Request a vault-kv backend when the relation joins."""
     vault = endpoint_from_flag("vault-kv.connected")
+    # pylint: disable-next=protected-access
     backend_name = vault_kv._get_secret_backend()
     # backend can't be isolated or VaultAppKV won't work; see issue #2
     vault.request_secret_backend(backend_name, isolated=False)
@@ -22,6 +26,7 @@ def request_vault_access():
 
 @when_all("vault-kv.available")
 def set_ready():
+    """Attempt to get the vault config to confirm the layer is ready."""
     try:
         vault_kv.get_vault_config()
     except vault_kv.VaultNotReady:
@@ -32,25 +37,30 @@ def set_ready():
 
 @when_all("layer.vault-kv.ready")
 def check_config_changed():
+    """Attempt to get the vault config to confirm the layer config is ready."""
     try:
         config = vault_kv.get_vault_config()
     except vault_kv.VaultNotReady:
-        return
+        pass
     else:
         if data_changed("layer.vault-kv.config", config):
             set_flag("layer.vault-kv.config.changed")
 
 
 def manage_app_kv_flags():
+    """Iterate through the reactive layer keys, setting what to notify the charm."""
     try:
         app_kv = vault_kv.VaultAppKV()
         for key in app_kv.keys():
+            # pylint: disable-next=protected-access
             app_kv._manage_flags(key)
     except vault_kv.VaultNotReady:
+        # pylint: disable-next=protected-access
         vault_kv.VaultAppKV._clear_all_flags()
 
 
 def update_app_kv_hashes():
+    """At hook end, ensure the app hash is consistent in VaultKV."""
     try:
         app_kv = vault_kv.VaultAppKV()
         if app_kv.any_changed():

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,11 @@ commands = pytest --tb native --cov-config={toxinidir}/tox.ini -s {posargs} {tox
 deps =
     black
     flake8
+    pylint
+    -r wheelhouse-lint.txt
 commands =
     flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
+    pylint {toxinidir}/reactive {toxinidir}/lib --extension-pkg-allow-list=charms.layer
     black --check {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
 
 [testenv:format]

--- a/wheelhouse-lint.txt
+++ b/wheelhouse-lint.txt
@@ -1,0 +1,3 @@
+-r wheelhouse.txt
+charms.reactive
+charms.unit_test


### PR DESCRIPTION
while creating a fix for LP#1949913, we merged https://github.com/juju-solutions/layer-vault-kv/pull/20 but there was a mistake in this PR that was very sneaky.  I happened to quickly find the mistake and patched https://github.com/juju-solutions/layer-vault-kv/pull/21 but could have found it originally if this repo was using pylint

Adding pylint and correcting lint mistakes in the reactive/ and lib/ paths

